### PR TITLE
feat(capture): harden mobile capture and microphone UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@
 
 ---
 
+## 0.9.0-alpha.3 - 2026-08-16
+
+### Добавлено
+- **Voice controller**: модульная state machine для browser speech с понятными состояниями и ошибками
+- **Microphone UX**: проверка permission перед каждой сессией, одноразовое объяснение Atlas и denied-инструкция
+- **Capture provenance**: `entryPoint` для обычного запуска, Android Share и manifest shortcut
+- **Диагностика**: статусы Voice, Microphone, Storage, сети и Service Worker
+
+### Исправлено
+- **Надёжность черновика**: единый немедленный flush при final voice result, background, pagehide, обновлении SW и ошибке сохранения
+- **Точность текста**: черновик сохраняет исходные пробелы и переносы строк; final transcript не дублируется
+- **Совместимость**: старые черновики и Inbox-записи без `entryPoint` безопасно получают значение `app`
+
+### Изменено
+- **Версия**: обновлена до `0.9.0-alpha.3`
+- **PWA cache**: новый voice-модуль включён в полный offline import graph
+
+---
+
 ## 0.9.0-alpha.2 - 2026-08-06
 
 ### Добавлено

--- a/capture/index.html
+++ b/capture/index.html
@@ -47,7 +47,7 @@
           </button>
           <button type="button" class="capture-btn capture-btn-save" id="btnSave">Сохранить</button>
         </div>
-        <div class="capture-voice-status" id="voiceStatus"></div>
+        <div class="capture-voice-status" id="voiceStatus" aria-live="polite"></div>
         <div class="capture-voice-note">Atlas не сохраняет аудиозапись. Распознавание выполняется средствами браузера.</div>
         <button type="button" class="capture-clear-draft" id="btnClearDraft" hidden>Очистить черновик</button>
       </div>
@@ -77,8 +77,10 @@
         <h2>Atlas Capture</h2>
         <div class="info-version" id="infoVersion"></div>
         <div class="info-status" id="infoStatus"></div>
+        <div class="info-storage" id="infoStorage"></div>
         <div class="info-sw" id="infoSW"></div>
-        <div class="info-inbox" id="infoInbox"></div>
+        <div class="info-voice" id="infoVoice"></div>
+        <div class="info-microphone" id="infoMicrophone"></div>
         <div class="info-note">Синхронизация между устройствами пока не реализована.</div>
         <button type="button" class="capture-btn capture-btn-secondary" id="btnBackFromInfo">Назад</button>
       </div>
@@ -123,6 +125,33 @@
         <button type="button" class="capture-btn" id="btnShareAppend">Добавить</button>
         <button type="button" class="capture-btn" id="btnShareReplace">Заменить</button>
         <button type="button" class="capture-btn capture-btn-secondary" id="btnShareCancel">Не принимать</button>
+      </div>
+    </div>
+  </dialog>
+
+  <dialog id="micIntroDialog" class="capture-dialog" aria-labelledby="micIntroTitle">
+    <div class="capture-dialog-content">
+      <h3 id="micIntroTitle">Голосовой ввод</h3>
+      <p>Atlas сохраняет только распознанный текст.</p>
+      <p>Само аудио Atlas не сохраняет.</p>
+      <p>Распознавание выполняет браузер или системная служба и в некоторых случаях может требовать интернет.</p>
+      <div class="capture-dialog-actions">
+        <button type="button" class="capture-btn" id="btnMicIntroContinue">Продолжить</button>
+        <button type="button" class="capture-btn capture-btn-secondary" id="btnMicIntroLater">Не сейчас</button>
+      </div>
+    </div>
+  </dialog>
+
+  <dialog id="micDeniedDialog" class="capture-dialog" aria-labelledby="micDeniedTitle">
+    <div class="capture-dialog-content">
+      <h3 id="micDeniedTitle">Микрофон отключён</h3>
+      <p>Доступ к микрофону для Atlas запрещён. Разрешите его в настройках сайта / браузера.</p>
+      <p id="micDeniedInstructions" class="capture-dialog-help" tabindex="-1" hidden>
+        Откройте сведения о сайте рядом с адресной строкой, найдите разрешение «Микрофон», выберите «Разрешить» и вернитесь в Atlas.
+      </p>
+      <div class="capture-dialog-actions">
+        <button type="button" class="capture-btn" id="btnMicDeniedHelp">Как включить</button>
+        <button type="button" class="capture-btn capture-btn-secondary" id="btnMicUseText">Использовать текст</button>
       </div>
     </div>
   </dialog>

--- a/capture/sw.js
+++ b/capture/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'atlas-capture-0.9.0-alpha.2';
+const CACHE_NAME = 'atlas-capture-0.9.0-alpha.3';
 
 const PRECACHE_ASSETS = [
   './',
@@ -9,6 +9,7 @@ const PRECACHE_ASSETS = [
   '../js/capture/draft.js',
   '../js/capture/pwa.js',
   '../js/capture/share-target.js',
+  '../js/capture/voice.js',
   '../js/state.js',
   '../js/storage.js',
   '../js/storageAdapter.js',

--- a/js/capture/app.js
+++ b/js/capture/app.js
@@ -4,22 +4,31 @@ import adapter from '../storageAdapter.js';
 import { captureInbox, deleteInbox, undoDeleteInbox } from '../core/commands.js';
 import { getInboxItems } from '../features/inbox/model.js';
 import { getDeviceId } from '../core/device.js';
-import { APP_VERSION, APP_LABEL } from '../version.js';
+import { APP_VERSION } from '../version.js';
 import { loadCaptureDraft, saveCaptureDraft, clearCaptureDraft } from './draft.js';
-import { registerCaptureServiceWorker, initInstallExperience, isStandalone, getServiceWorkerStatus } from './pwa.js';
-import { initShareTarget, applyShareDraft, mergeShareWithExisting } from './share-target.js';
+import { registerCaptureServiceWorker, initInstallExperience, getServiceWorkerStatus } from './pwa.js';
+import { initShareTarget, applyShareDraft, mergeShareDrafts, resolveShortcutEntryPoint } from './share-target.js';
+import {
+  VOICE_STATES,
+  appendFinalTranscript,
+  createVoiceController,
+  queryMicrophonePermission,
+} from './voice.js';
 
 const RECENT_LIMIT = 8;
 const DRAFT_DEBOUNCE_MS = 400;
+const MIC_INTRO_KEY = 'atlas_capture_mic_intro_v1';
 
 let currentView = 'capture';
 let currentUserHint = null;
 let currentInputType = 'text';
-let isRecording = false;
-let recognition = null;
+let currentEntryPoint = 'app';
+let voiceController = null;
+let microphonePermission = 'unknown';
 let lastRemoval = null;
 let toastTimer = null;
 let storageOk = true;
+let draftStorageOk = true;
 let draftSaveTimer = null;
 let hasDraft = false;
 
@@ -99,17 +108,34 @@ function updateCounter() {
 function scheduleDraftSave() {
   if (draftSaveTimer) clearTimeout(draftSaveTimer);
   draftSaveTimer = setTimeout(() => {
-    const textarea = document.getElementById('captureText');
-    const text = safeGetValue(textarea).trim();
-    if (text) {
-      hasDraft = true;
-      saveCaptureDraft({ text, userHint: currentUserHint, inputType: currentInputType });
-    } else {
-      hasDraft = false;
-      clearCaptureDraft();
-    }
-    updateClearDraftVisibility();
+    draftSaveTimer = null;
+    flushCaptureDraft();
   }, DRAFT_DEBOUNCE_MS);
+}
+
+export function flushCaptureDraft() {
+  if (draftSaveTimer) {
+    clearTimeout(draftSaveTimer);
+    draftSaveTimer = null;
+  }
+
+  const text = safeGetValue(document.getElementById('captureText'));
+  if (!text.trim()) {
+    hasDraft = false;
+    draftStorageOk = clearCaptureDraft();
+    updateClearDraftVisibility();
+    return draftStorageOk;
+  }
+
+  hasDraft = true;
+  draftStorageOk = saveCaptureDraft({
+    text,
+    userHint: currentUserHint,
+    inputType: currentInputType,
+    entryPoint: currentEntryPoint,
+  });
+  updateClearDraftVisibility();
+  return draftStorageOk;
 }
 
 function renderRecentItems() {
@@ -290,13 +316,16 @@ function restoreHintUI() {
 
 function saveCapture() {
   if (!storageOk) {
-    showToast('Хранилище недоступно');
+    const draftSaved = flushCaptureDraft();
+    showToast(draftSaved
+      ? 'Не удалось сохранить во Входящие. Текст оставлен в черновике.'
+      : 'Не удалось сохранить запись. Текст оставлен на экране — скопируйте его перед закрытием.', 8000);
     return;
   }
 
   const textarea = document.getElementById('captureText');
-  const text = safeGetValue(textarea).trim();
-  if (!text) {
+  const text = safeGetValue(textarea);
+  if (!text.trim()) {
     textarea.focus();
     return;
   }
@@ -310,6 +339,7 @@ function saveCapture() {
       status: 'new',
       userHint: currentUserHint,
       deviceId: getDeviceId(),
+      entryPoint: currentEntryPoint,
       splitLines: false,
     });
 
@@ -319,6 +349,7 @@ function saveCapture() {
       hasDraft = false;
       currentUserHint = null;
       currentInputType = 'text';
+      currentEntryPoint = 'app';
       document.querySelectorAll('.capture-hint').forEach(btn => {
         btn.classList.remove('active');
         btn.setAttribute('aria-pressed', 'false');
@@ -331,85 +362,171 @@ function saveCapture() {
     }
   } catch (err) {
     updateStatus('Не удалось сохранить');
-    showToast('Ошибка сохранения');
+    const draftSaved = flushCaptureDraft();
+    showToast(draftSaved
+      ? 'Не удалось сохранить во Входящие. Текст оставлен в черновике.'
+      : 'Не удалось сохранить запись. Текст оставлен на экране — скопируйте его перед закрытием.', 8000);
   }
 }
 
-function initVoice() {
-  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-  const btnMic = document.getElementById('btnMic');
-  const voiceStatus = document.getElementById('voiceStatus');
+const VOICE_STATUS_TEXT = {
+  [VOICE_STATES.UNSUPPORTED]: 'Голосовой ввод недоступен в этом браузере. Текстовые записи продолжают работать.',
+  [VOICE_STATES.IDLE]: '',
+  [VOICE_STATES.REQUESTING]: 'Запрашиваю доступ…',
+  [VOICE_STATES.LISTENING]: 'Слушаю…',
+  [VOICE_STATES.PROCESSING]: 'Распознаю…',
+  [VOICE_STATES.RESULT]: 'Проверьте текст',
+  [VOICE_STATES.NO_SPEECH]: 'Речь не распознана. Попробуйте ещё раз.',
+  [VOICE_STATES.DENIED]: 'Микрофон отключён. Разрешите доступ в настройках сайта / браузера.',
+  [VOICE_STATES.AUDIO_ERROR]: 'Не удалось получить доступ к микрофону.',
+  [VOICE_STATES.NETWORK_ERROR]: 'Для голосового распознавания сейчас нет соединения.',
+  [VOICE_STATES.LANGUAGE_ERROR]: 'Русский язык распознавания сейчас недоступен.',
+  [VOICE_STATES.GENERIC_ERROR]: 'Не удалось распознать речь.',
+  [VOICE_STATES.ABORTED]: 'Голосовой ввод остановлен.',
+};
 
-  if (!SpeechRecognition) {
-    btnMic.disabled = true;
-    btnMic.title = 'Голосовой ввод не поддерживается этим браузером';
-    safeSetText(voiceStatus, 'Голосовой ввод не поддерживается этим браузером.');
+function updateVoiceUI(state) {
+  const btnMic = document.getElementById('btnMic');
+  const listening = state === VOICE_STATES.LISTENING;
+  btnMic.classList.toggle('recording', listening);
+  btnMic.setAttribute('aria-pressed', listening ? 'true' : 'false');
+  safeSetText(document.getElementById('voiceStatus'), VOICE_STATUS_TEXT[state] || '');
+}
+
+function hasSeenMicIntro() {
+  try {
+    return localStorage.getItem(MIC_INTRO_KEY) === 'seen';
+  } catch (_) {
+    return false;
+  }
+}
+
+function markMicIntroSeen() {
+  try {
+    localStorage.setItem(MIC_INTRO_KEY, 'seen');
+  } catch (_) {}
+}
+
+function showMicIntroDialog() {
+  const dialog = document.getElementById('micIntroDialog');
+  if (!dialog) return Promise.resolve(true);
+  markMicIntroSeen();
+
+  return new Promise(resolve => {
+    const btnContinue = document.getElementById('btnMicIntroContinue');
+    const btnLater = document.getElementById('btnMicIntroLater');
+
+    function finish(shouldContinue) {
+      btnContinue.removeEventListener('click', onContinue);
+      btnLater.removeEventListener('click', onLater);
+      dialog.removeEventListener('cancel', onCancel);
+      if (dialog.open) dialog.close();
+      resolve(shouldContinue);
+    }
+    function onContinue() { finish(true); }
+    function onLater() { finish(false); }
+    function onCancel(event) {
+      event.preventDefault();
+      finish(false);
+    }
+
+    btnContinue.addEventListener('click', onContinue);
+    btnLater.addEventListener('click', onLater);
+    dialog.addEventListener('cancel', onCancel);
+    dialog.showModal();
+  });
+}
+
+function showMicDeniedDialog() {
+  const dialog = document.getElementById('micDeniedDialog');
+  if (!dialog || dialog.open) return;
+  const btnHelp = document.getElementById('btnMicDeniedHelp');
+  const btnText = document.getElementById('btnMicUseText');
+  const help = document.getElementById('micDeniedInstructions');
+
+  help.hidden = true;
+  function cleanup() {
+    btnHelp.removeEventListener('click', onHelp);
+    btnText.removeEventListener('click', onText);
+  }
+  function onHelp() {
+    help.hidden = false;
+    help.focus();
+  }
+  function onText() {
+    cleanup();
+    dialog.close();
+    document.getElementById('captureText').focus();
+  }
+
+  btnHelp.addEventListener('click', onHelp);
+  btnText.addEventListener('click', onText);
+  dialog.addEventListener('close', cleanup, { once: true });
+  dialog.showModal();
+}
+
+async function refreshMicrophonePermission() {
+  microphonePermission = await queryMicrophonePermission(navigator);
+  return microphonePermission;
+}
+
+async function beginVoiceSession() {
+  if (!voiceController?.isSupported()) return;
+  const permission = await refreshMicrophonePermission();
+  if (permission === 'denied') {
+    updateVoiceUI(VOICE_STATES.DENIED);
+    showMicDeniedDialog();
     return;
   }
 
-  recognition = new SpeechRecognition();
-  recognition.lang = 'ru-RU';
-  recognition.continuous = false;
-  recognition.interimResults = true;
-
-  recognition.onstart = () => {
-    isRecording = true;
-    btnMic.classList.add('recording');
-    btnMic.setAttribute('aria-pressed', 'true');
-    safeSetText(voiceStatus, 'Слушаю…');
-  };
-
-  recognition.onresult = (event) => {
-    let interim = '';
-    let final = '';
-    for (let i = event.resultIndex; i < event.results.length; i++) {
-      const transcript = event.results[i][0].transcript;
-      if (event.results[i].isFinal) {
-        final += transcript;
-      } else {
-        interim += transcript;
-      }
+  if (!hasSeenMicIntro()) {
+    const shouldContinue = await showMicIntroDialog();
+    if (!shouldContinue) {
+      updateVoiceUI(VOICE_STATES.IDLE);
+      document.getElementById('btnMic').focus();
+      return;
     }
+  }
 
-    const textarea = document.getElementById('captureText');
-    if (final) {
-      const current = safeGetValue(textarea);
-      textarea.value = current ? current + ' ' + final : final;
+  voiceController.start();
+}
+
+function initVoice() {
+  const btnMic = document.getElementById('btnMic');
+  voiceController = createVoiceController({
+    lang: 'ru-RU',
+    scope: window,
+    onState: updateVoiceUI,
+    onInterim: () => safeSetText(document.getElementById('voiceStatus'), 'Распознаю…'),
+    onFinal: transcript => {
+      const textarea = document.getElementById('captureText');
+      textarea.value = appendFinalTranscript(safeGetValue(textarea), transcript);
       currentInputType = 'voice';
-      safeSetText(voiceStatus, 'Проверьте текст');
-      scheduleDraftSave();
-    } else if (interim) {
-      safeSetText(voiceStatus, 'Распознаю…');
-    }
-  };
-
-  recognition.onerror = (event) => {
-    isRecording = false;
-    btnMic.classList.remove('recording');
-    btnMic.setAttribute('aria-pressed', 'false');
-    if (event.error === 'not-allowed') {
-      safeSetText(voiceStatus, 'Доступ к микрофону запрещён. Разрешите в настройках браузера.');
-    } else {
-      safeSetText(voiceStatus, 'Ошибка распознавания');
-    }
-  };
-
-  recognition.onend = () => {
-    isRecording = false;
-    btnMic.classList.remove('recording');
-    btnMic.setAttribute('aria-pressed', 'false');
-  };
-
-  btnMic.addEventListener('click', () => {
-    if (isRecording) {
-      recognition.stop();
-    } else {
-      try {
-        recognition.start();
-      } catch (e) {
-        safeSetText(voiceStatus, 'Не удалось запустить распознавание');
+      flushCaptureDraft();
+    },
+    onError: state => {
+      if (state === VOICE_STATES.DENIED) {
+        microphonePermission = 'denied';
+        showMicDeniedDialog();
       }
+    },
+  });
+
+  if (!voiceController.isSupported()) {
+    btnMic.disabled = true;
+    btnMic.title = 'Голосовой ввод недоступен в этом браузере';
+    updateVoiceUI(VOICE_STATES.UNSUPPORTED);
+    return;
+  }
+
+  updateVoiceUI(VOICE_STATES.IDLE);
+  btnMic.addEventListener('click', () => {
+    const state = voiceController.getState();
+    if ([VOICE_STATES.REQUESTING, VOICE_STATES.LISTENING, VOICE_STATES.PROCESSING].includes(state)) {
+      voiceController.stop();
+      return;
     }
+    beginVoiceSession();
   });
 }
 
@@ -423,6 +540,7 @@ function restoreDraft() {
   }
   currentUserHint = draft.userHint;
   currentInputType = draft.inputType;
+  currentEntryPoint = draft.entryPoint;
   hasDraft = true;
   restoreHintUI();
   updateClearDraftVisibility();
@@ -471,8 +589,9 @@ function init() {
       textarea.value = result.draft.text;
       currentUserHint = result.draft.userHint;
       currentInputType = result.draft.inputType;
+      currentEntryPoint = result.draft.entryPoint;
       hasDraft = true;
-      saveCaptureDraft(result.draft);
+      flushCaptureDraft();
       restoreHintUI();
       updateClearDraftVisibility();
       showToast('Получено через «Поделиться». Проверьте запись перед сохранением.', 5000);
@@ -498,6 +617,7 @@ function init() {
     clearCaptureDraft();
     currentUserHint = null;
     currentInputType = 'text';
+    currentEntryPoint = 'app';
     hasDraft = false;
     document.querySelectorAll('.capture-hint').forEach(btn => {
       btn.classList.remove('active');
@@ -529,23 +649,28 @@ function init() {
     }
   });
 
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      flushCaptureDraft();
+    } else {
+      refreshMicrophonePermission();
+    }
+  });
+  window.addEventListener('pagehide', flushCaptureDraft);
+  window.addEventListener('beforeunload', flushCaptureDraft);
+
   initVoice();
   initOnlineStatus();
   registerCaptureServiceWorker({
     showToast,
-    flushDraft: () => {
-      const textarea = document.getElementById('captureText');
-      const text = safeGetValue(textarea).trim();
-      if (text) {
-        saveCaptureDraft({ text, userHint: currentUserHint, inputType: currentInputType });
-      }
-    }
+    flushDraft: flushCaptureDraft,
   });
   initInstallExperience();
 
   const params = new URLSearchParams(window.location.search);
   const action = params.get('action');
   if (action === 'new') {
+    currentEntryPoint = resolveShortcutEntryPoint(loadCaptureDraft());
     navigateTo('capture');
     clearShareParamsFromUrl();
   } else {
@@ -580,10 +705,10 @@ function initOnlineStatus() {
     const online = navigator.onLine;
     const statusEl = document.getElementById('status');
     if (online) {
-      safeSetText(statusEl, 'Онлайн · локальные записи сохранены');
+      safeSetText(statusEl, 'Онлайн · текстовые записи сохраняются локально');
       statusEl.classList.remove('offline');
     } else {
-      safeSetText(statusEl, 'Офлайн · записи сохраняются на устройстве');
+      safeSetText(statusEl, 'Офлайн · текстовые записи работают. Голос может быть недоступен.');
       statusEl.classList.add('offline');
     }
   };
@@ -610,12 +735,13 @@ function showShareChoiceDialog(shareDraft, existingDraft) {
 
   function onAppend() {
     const textarea = document.getElementById('captureText');
-    const merged = mergeShareWithExisting(existingDraft.text, shareDraft.text);
-    textarea.value = merged;
-    currentUserHint = existingDraft.userHint || shareDraft.userHint;
-    currentInputType = shareDraft.inputType;
+    const merged = mergeShareDrafts(existingDraft, shareDraft);
+    textarea.value = merged.text;
+    currentUserHint = merged.userHint;
+    currentInputType = merged.inputType;
+    currentEntryPoint = merged.entryPoint;
     hasDraft = true;
-    saveCaptureDraft({ text: merged, userHint: currentUserHint, inputType: currentInputType });
+    flushCaptureDraft();
     restoreHintUI();
     updateClearDraftVisibility();
     showToast('Текст добавлен к черновику', 3000);
@@ -627,8 +753,9 @@ function showShareChoiceDialog(shareDraft, existingDraft) {
     textarea.value = shareDraft.text;
     currentUserHint = shareDraft.userHint;
     currentInputType = shareDraft.inputType;
+    currentEntryPoint = shareDraft.entryPoint;
     hasDraft = true;
-    saveCaptureDraft(shareDraft);
+    flushCaptureDraft();
     restoreHintUI();
     updateClearDraftVisibility();
     showToast('Черновик заменён', 3000);
@@ -647,21 +774,35 @@ function showShareChoiceDialog(shareDraft, existingDraft) {
   dialog.showModal();
 }
 
-function updateInfoPanel() {
+async function updateInfoPanel() {
   const versionEl = document.getElementById('infoVersion');
   const statusEl = document.getElementById('infoStatus');
+  const storageEl = document.getElementById('infoStorage');
   const swEl = document.getElementById('infoSW');
-  const inboxEl = document.getElementById('infoInbox');
+  const voiceEl = document.getElementById('infoVoice');
+  const microphoneEl = document.getElementById('infoMicrophone');
+
+  await refreshMicrophonePermission();
+  const permissionLabels = {
+    granted: 'Разрешено',
+    prompt: 'Требуется запрос',
+    denied: 'Запрещено',
+    unknown: 'Неизвестно',
+  };
   
   safeSetText(versionEl, `Версия: ${APP_VERSION}`);
-  safeSetText(statusEl, navigator.onLine ? 'Онлайн' : 'Офлайн');
+  safeSetText(statusEl, `Сеть: ${navigator.onLine ? 'Онлайн' : 'Офлайн'}`);
+  safeSetText(storageEl, `Storage: ${storageOk && draftStorageOk ? 'Доступно' : 'Ошибка'}`);
   safeSetText(swEl, `Service Worker: ${getServiceWorkerStatus()}`);
-  
-  const count = Array.isArray(state.inbox) ? state.inbox.length : 0;
-  safeSetText(inboxEl, `Записей в Inbox: ${count}`);
+  safeSetText(voiceEl, `Voice: ${voiceController?.isSupported() ? 'Поддерживается' : 'Не поддерживается'}`);
+  safeSetText(microphoneEl, `Microphone: ${permissionLabels[microphonePermission]}`);
 }
 
 function navigateTo(view) {
+  if (currentView === 'capture' && view !== 'capture') {
+    const text = safeGetValue(document.getElementById('captureText'));
+    if (text.trim()) flushCaptureDraft();
+  }
   currentView = view;
   const captureView = document.getElementById('captureView');
   const inboxView = document.getElementById('inboxView');

--- a/js/capture/draft.js
+++ b/js/capture/draft.js
@@ -1,17 +1,17 @@
 const DRAFT_KEY = 'atlas_capture_draft_v1';
 
+const VALID_ENTRY_POINTS = new Set(['app', 'share', 'shortcut']);
+
+function normalizeEntryPoint(value) {
+  return VALID_ENTRY_POINTS.has(value) ? value : 'app';
+}
+
 export function loadCaptureDraft() {
   try {
     const raw = localStorage.getItem(DRAFT_KEY);
     if (!raw) return null;
     const data = JSON.parse(raw);
-    if (!data || typeof data !== 'object') return null;
-    return {
-      text: typeof data.text === 'string' ? data.text : '',
-      userHint: ['task', 'thought', 'note'].includes(data.userHint) ? data.userHint : null,
-      inputType: data.inputType === 'voice' ? 'voice' : 'text',
-      updatedAt: Number(data.updatedAt) || Date.now(),
-    };
+    return normalizeCaptureDraft(data);
   } catch (_) {
     return null;
   }
@@ -23,6 +23,7 @@ export function saveCaptureDraft(draft) {
       text: typeof draft.text === 'string' ? draft.text : '',
       userHint: ['task', 'thought', 'note'].includes(draft.userHint) ? draft.userHint : null,
       inputType: draft.inputType === 'voice' ? 'voice' : 'text',
+      entryPoint: normalizeEntryPoint(draft.entryPoint),
       updatedAt: Date.now(),
     };
     localStorage.setItem(DRAFT_KEY, JSON.stringify(data));
@@ -35,17 +36,21 @@ export function saveCaptureDraft(draft) {
 export function clearCaptureDraft() {
   try {
     localStorage.removeItem(DRAFT_KEY);
-  } catch (_) {}
+    return true;
+  } catch (_) {
+    return false;
+  }
 }
 
 export function normalizeCaptureDraft(value) {
   if (!value || typeof value !== 'object') return null;
-  const text = typeof value.text === 'string' ? value.text.trim() : '';
-  if (!text) return null;
+  const text = typeof value.text === 'string' ? value.text : '';
+  if (!text.trim()) return null;
   return {
     text,
     userHint: ['task', 'thought', 'note'].includes(value.userHint) ? value.userHint : null,
     inputType: value.inputType === 'voice' ? 'voice' : 'text',
+    entryPoint: normalizeEntryPoint(value.entryPoint),
     updatedAt: Number(value.updatedAt) || Date.now(),
   };
 }

--- a/js/capture/pwa.js
+++ b/js/capture/pwa.js
@@ -83,8 +83,11 @@ export function showUpdateAvailable() {
 
   if (btnUpdate) {
     btnUpdate.addEventListener('click', () => {
-      if (flushDraftCallback) {
-        flushDraftCallback();
+      if (flushDraftCallback && flushDraftCallback() === false) {
+        if (showToastCallback) {
+          showToastCallback('Не удалось сохранить черновик. Обновление отложено.', 6000);
+        }
+        return;
       }
       if (registration && registration.waiting) {
         registration.waiting.postMessage({ type: 'SKIP_WAITING' });
@@ -143,7 +146,7 @@ export function isStandalone() {
 export function getServiceWorkerStatus() {
   if (!('serviceWorker' in navigator)) return 'не поддерживается';
   if (!registration) return 'не зарегистрирован';
-  if (registration.active && registration.waiting) return 'ождает обновления';
+  if (registration.active && registration.waiting) return 'ожидает обновления';
   if (registration.active) return 'активен';
   return 'устанавливается';
 }

--- a/js/capture/share-target.js
+++ b/js/capture/share-target.js
@@ -31,6 +31,7 @@ export function buildShareDraft(title, text, url) {
     text: combined,
     userHint: 'note',
     inputType: 'text',
+    entryPoint: 'share',
   };
 }
 
@@ -46,6 +47,24 @@ export function applyShareDraft(draft, existingDraft) {
 
 export function mergeShareWithExisting(existingText, sharedText) {
   return existingText + '\n\n' + sharedText;
+}
+
+export function mergeShareDrafts(existingDraft, sharedDraft) {
+  return {
+    text: mergeShareWithExisting(existingDraft.text, sharedDraft.text),
+    userHint: existingDraft.userHint || sharedDraft.userHint || null,
+    inputType: existingDraft.inputType === 'voice' ? 'voice' : 'text',
+    entryPoint: 'share',
+  };
+}
+
+export function resolveShortcutEntryPoint(existingDraft) {
+  if (existingDraft?.text?.trim()) {
+    return ['app', 'share', 'shortcut'].includes(existingDraft.entryPoint)
+      ? existingDraft.entryPoint
+      : 'app';
+  }
+  return 'shortcut';
 }
 
 function sanitizeText(value) {

--- a/js/capture/voice.js
+++ b/js/capture/voice.js
@@ -1,0 +1,205 @@
+export const VOICE_STATES = Object.freeze({
+  UNSUPPORTED: 'unsupported',
+  IDLE: 'idle',
+  REQUESTING: 'requesting',
+  LISTENING: 'listening',
+  PROCESSING: 'processing',
+  RESULT: 'result',
+  NO_SPEECH: 'no-speech',
+  DENIED: 'denied',
+  AUDIO_ERROR: 'audio-error',
+  NETWORK_ERROR: 'network-error',
+  LANGUAGE_ERROR: 'language-error',
+  GENERIC_ERROR: 'generic-error',
+  ABORTED: 'aborted',
+});
+
+const ACTIVE_STATES = new Set([
+  VOICE_STATES.REQUESTING,
+  VOICE_STATES.LISTENING,
+  VOICE_STATES.PROCESSING,
+]);
+
+export function getSpeechRecognitionConstructor(scope = globalThis) {
+  return scope?.SpeechRecognition || scope?.webkitSpeechRecognition || null;
+}
+
+export async function queryMicrophonePermission(navigatorLike = globalThis.navigator) {
+  try {
+    if (!navigatorLike?.permissions?.query) return 'unknown';
+    const status = await navigatorLike.permissions.query({ name: 'microphone' });
+    return ['granted', 'prompt', 'denied'].includes(status?.state)
+      ? status.state
+      : 'unknown';
+  } catch (_) {
+    return 'unknown';
+  }
+}
+
+export function mapSpeechRecognitionError(error) {
+  const code = typeof error === 'string' ? error : error?.error;
+  if (code === 'not-allowed' || code === 'service-not-allowed') {
+    return VOICE_STATES.DENIED;
+  }
+  if (code === 'no-speech') return VOICE_STATES.NO_SPEECH;
+  if (code === 'audio-capture') return VOICE_STATES.AUDIO_ERROR;
+  if (code === 'network') return VOICE_STATES.NETWORK_ERROR;
+  if (code === 'language-not-supported' || code === 'language-unavailable') {
+    return VOICE_STATES.LANGUAGE_ERROR;
+  }
+  if (code === 'aborted') return VOICE_STATES.ABORTED;
+  return VOICE_STATES.GENERIC_ERROR;
+}
+
+export function appendFinalTranscript(existingText, finalTranscript) {
+  const existing = typeof existingText === 'string' ? existingText : '';
+  const finalText = typeof finalTranscript === 'string' ? finalTranscript.trim() : '';
+  if (!finalText) return existing;
+  if (!existing) return finalText;
+  return /\s$/.test(existing) ? `${existing}${finalText}` : `${existing} ${finalText}`;
+}
+
+export function createVoiceController({
+  lang = 'ru-RU',
+  onState = () => {},
+  onInterim = () => {},
+  onFinal = () => {},
+  onError = () => {},
+  scope = globalThis,
+} = {}) {
+  const Recognition = getSpeechRecognitionConstructor(scope);
+  let recognition = null;
+  let state = Recognition ? VOICE_STATES.IDLE : VOICE_STATES.UNSUPPORTED;
+  let processedFinalIndexes = new Set();
+  let recognitionRunning = false;
+
+  function setState(nextState) {
+    state = nextState;
+    onState(nextState);
+  }
+
+  function ensureRecognition() {
+    if (!Recognition) return null;
+    if (recognition) return recognition;
+
+    recognition = new Recognition();
+    recognition.lang = lang;
+    recognition.continuous = false;
+    recognition.interimResults = true;
+
+    recognition.onstart = () => {
+      recognitionRunning = true;
+      setState(VOICE_STATES.LISTENING);
+    };
+    recognition.onspeechend = () => {
+      if (state === VOICE_STATES.LISTENING) setState(VOICE_STATES.PROCESSING);
+    };
+    recognition.onaudioend = () => {
+      if (state === VOICE_STATES.LISTENING) setState(VOICE_STATES.PROCESSING);
+    };
+    recognition.onresult = event => {
+      let interim = '';
+      const finalParts = [];
+
+      for (let index = event.resultIndex; index < event.results.length; index += 1) {
+        const result = event.results[index];
+        const transcript = result?.[0]?.transcript || '';
+        if (result?.isFinal) {
+          if (!processedFinalIndexes.has(index)) {
+            processedFinalIndexes.add(index);
+            finalParts.push(transcript);
+          }
+        } else {
+          interim += transcript;
+        }
+      }
+
+      if (interim) onInterim(interim);
+      if (finalParts.length > 0) {
+        const finalTranscript = finalParts.map(part => part.trim()).filter(Boolean).join(' ');
+        setState(VOICE_STATES.RESULT);
+        onFinal(finalTranscript);
+      }
+    };
+    recognition.onerror = event => {
+      const nextState = mapSpeechRecognitionError(event);
+      setState(nextState);
+      onError(nextState, event?.error || 'unknown');
+    };
+    recognition.onend = () => {
+      recognitionRunning = false;
+      if (ACTIVE_STATES.has(state)) setState(VOICE_STATES.IDLE);
+    };
+
+    return recognition;
+  }
+
+  function start() {
+    if (!Recognition) {
+      setState(VOICE_STATES.UNSUPPORTED);
+      return false;
+    }
+    if (recognitionRunning || ACTIVE_STATES.has(state)) return false;
+
+    processedFinalIndexes = new Set();
+    setState(VOICE_STATES.REQUESTING);
+    try {
+      recognitionRunning = true;
+      ensureRecognition().start();
+      return true;
+    } catch (error) {
+      recognitionRunning = false;
+      setState(VOICE_STATES.GENERIC_ERROR);
+      onError(VOICE_STATES.GENERIC_ERROR, error?.name || 'start-failed');
+      return false;
+    }
+  }
+
+  function stop() {
+    if (!recognition || !recognitionRunning) return false;
+    try {
+      recognition.stop();
+      if (state === VOICE_STATES.LISTENING) setState(VOICE_STATES.PROCESSING);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function abort() {
+    if (!recognition || !recognitionRunning) return false;
+    try {
+      recognition.abort();
+      setState(VOICE_STATES.ABORTED);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function destroy() {
+    if (recognition) {
+      try {
+        if (recognitionRunning) recognition.abort();
+      } catch (_) {}
+      recognition.onstart = null;
+      recognition.onspeechend = null;
+      recognition.onaudioend = null;
+      recognition.onresult = null;
+      recognition.onerror = null;
+      recognition.onend = null;
+      recognition = null;
+      recognitionRunning = false;
+    }
+    setState(Recognition ? VOICE_STATES.IDLE : VOICE_STATES.UNSUPPORTED);
+  }
+
+  return {
+    start,
+    stop,
+    abort,
+    destroy,
+    getState: () => state,
+    isSupported: () => Boolean(Recognition),
+  };
+}

--- a/js/features/inbox/model.js
+++ b/js/features/inbox/model.js
@@ -10,13 +10,16 @@ function makeId(prefix = 'inbox'){
 }
 
 export function getInboxItems(){
-  return [...ensureInbox()].sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+  return ensureInbox()
+    .map(item => ({ ...item, entryPoint: normalizeEntryPoint(item.entryPoint) }))
+    .sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
 }
 
 const VALID_INPUT_TYPES = new Set(['text', 'voice']);
 const VALID_USER_HINTS = new Set(['task', 'thought', 'note']);
 const VALID_STATUSES = new Set(['new', 'reviewed', 'processed', 'discarded']);
 const VALID_SOURCES = new Set(['desktop-capture', 'mobile-capture']);
+const VALID_ENTRY_POINTS = new Set(['app', 'share', 'shortcut']);
 
 function normalizeInputType(value){
   return VALID_INPUT_TYPES.has(value) ? value : 'text';
@@ -34,12 +37,16 @@ function normalizeSource(value){
   return VALID_SOURCES.has(value) ? value : 'desktop-capture';
 }
 
+export function normalizeEntryPoint(value){
+  return VALID_ENTRY_POINTS.has(value) ? value : 'app';
+}
+
 export function addInboxLines(text, options = {}){
   const rawText = String(text || '');
   const splitLines = options.splitLines !== false;
   const lines = splitLines
     ? rawText.split(/\r?\n/).map(line => line.trim()).filter(Boolean)
-    : [rawText.trim()];
+    : rawText.trim() ? [rawText] : [];
 
   if (lines.length === 0) return [];
 
@@ -50,6 +57,7 @@ export function addInboxLines(text, options = {}){
   const status = normalizeStatus(options.status);
   const userHint = normalizeUserHint(options.userHint);
   const deviceId = options.deviceId || null;
+  const entryPoint = normalizeEntryPoint(options.entryPoint);
 
   const created = lines.map((line, index) => ({
     id: idFactory(index),
@@ -60,6 +68,7 @@ export function addInboxLines(text, options = {}){
     status,
     userHint,
     deviceId,
+    entryPoint,
     createdAt: now,
     updatedAt: now,
   }));

--- a/js/version.js
+++ b/js/version.js
@@ -1,3 +1,3 @@
 export const APP_NAME = 'Atlas of Life';
-export const APP_VERSION = '0.9.0-alpha.2';
+export const APP_VERSION = '0.9.0-alpha.3';
 export const APP_LABEL = `${APP_NAME} ${APP_VERSION}`;

--- a/styles/capture.css
+++ b/styles/capture.css
@@ -650,8 +650,10 @@ body {
 
 .info-version,
 .info-status,
+.info-storage,
 .info-sw,
-.info-inbox {
+.info-voice,
+.info-microphone {
   font-size: 14px;
   color: var(--text-muted);
 }
@@ -751,6 +753,17 @@ body {
   font-size: 14px;
   color: var(--text-muted);
   margin: 0;
+}
+
+.capture-dialog-help {
+  padding: 10px;
+  border-radius: 8px;
+  background: var(--bg-input);
+  line-height: 1.5;
+}
+
+.capture-dialog-help[hidden] {
+  display: none;
 }
 
 .capture-dialog-actions {

--- a/tests/capture-persistence.mjs
+++ b/tests/capture-persistence.mjs
@@ -1,5 +1,5 @@
 import { state } from '../js/state.js';
-import { addInboxLines } from '../js/features/inbox/model.js';
+import { addInboxLines, getInboxItems } from '../js/features/inbox/model.js';
 import { captureInbox, deleteInbox, undoDeleteInbox } from '../js/core/commands.js';
 import { loadState, saveState } from '../js/storage.js';
 import adapter from '../js/storageAdapter.js';
@@ -107,6 +107,7 @@ assert(t10.length === 1, 'Test 10: old call should work');
 assert(t10[0].text === 'Старый вызов', 'Test 10: text should be saved');
 assert(t10[0].inputType === 'text', 'Test 10: default inputType should be text');
 assert(t10[0].source === 'desktop-capture', 'Test 10: default source should be desktop-capture');
+assert(t10[0].entryPoint === 'app', 'Test 10: default entryPoint should be app');
 console.log('✓ Test 10: old captureInbox(text) works');
 
 // Test 11: desktop splitLines creates multiple items
@@ -136,6 +137,7 @@ const t13 = captureInbox('Многострочная\nпроверка\nсохр
   status: 'new',
   userHint: 'thought',
   deviceId: 'device-save',
+  entryPoint: 'share',
   splitLines: false,
   persist: true,
   now: 2000,
@@ -158,6 +160,9 @@ assert(restored.source === 'mobile-capture', 'Test 13: source after reload');
 assert(restored.status === 'new', 'Test 13: status after reload');
 assert(restored.userHint === 'thought', 'Test 13: userHint after reload');
 assert(restored.deviceId === 'device-save', 'Test 13: deviceId after reload');
+assert(restored.entryPoint === 'share', 'Test 13: entryPoint after reload');
+const captureOperation = state.operationLog.find(operation => operation.type === 'inbox.capture');
+assert(captureOperation?.payload?.entryPoint === 'share', 'Test 13: operation payload should include entryPoint');
 console.log('✓ Test 13: extra fields survive full save/load cycle');
 
 // Test 14: storage error fully rolls back mobile record
@@ -285,12 +290,31 @@ const t18c = captureInbox('\n\n\n', opts());
 assert(t18c.length === 0, 'Test 18c: newlines should not create item');
 console.log('✓ Test 18: empty records not saved');
 
+// Test 18d: entryPoint normalization and exact non-split text
+resetState();
+const appEntry = captureInbox('App', opts({ entryPoint: 'app' }));
+const shareEntry = captureInbox('Share', opts({ entryPoint: 'share', now: 1001, idFactory: () => 'share' }));
+const shortcutEntry = captureInbox('Shortcut', opts({ entryPoint: 'shortcut', now: 1002, idFactory: () => 'shortcut' }));
+const unknownEntry = captureInbox('Unknown', opts({ entryPoint: 'widget', now: 1003, idFactory: () => 'unknown' }));
+assert(appEntry[0].entryPoint === 'app', 'Test 18d: app entryPoint');
+assert(shareEntry[0].entryPoint === 'share', 'Test 18d: share entryPoint');
+assert(shortcutEntry[0].entryPoint === 'shortcut', 'Test 18d: shortcut entryPoint');
+assert(unknownEntry[0].entryPoint === 'app', 'Test 18d: unknown entryPoint should normalize to app');
+const exactText = '  первая строка\nвторая строка  ';
+const exactEntry = captureInbox(exactText, opts({ splitLines: false, now: 1004, idFactory: () => 'exact' }));
+assert(exactEntry[0].rawText === exactText, 'Test 18d: non-split rawText should remain exact');
+console.log('✓ Test 18d: entryPoint and exact non-split text');
+
+state.inbox = [{ id: 'legacy', text: 'Старая запись', createdAt: 1 }];
+assert(getInboxItems()[0].entryPoint === 'app', 'Test 18e: old Inbox item should normalize entryPoint to app');
+console.log('✓ Test 18e: old Inbox item compatibility');
+
 // Test 19-22: Draft tests
 const { loadCaptureDraft, saveCaptureDraft, clearCaptureDraft, normalizeCaptureDraft } = await import('../js/capture/draft.js');
 
 // Test 19: draft serializes and deserializes
 resetState();
-const draftData = { text: 'Черновик записи', userHint: 'task', inputType: 'voice' };
+const draftData = { text: 'Черновик записи', userHint: 'task', inputType: 'voice', entryPoint: 'shortcut' };
 const savedDraft = saveCaptureDraft(draftData);
 assert(savedDraft === true, 'Test 19: saveCaptureDraft should return true');
 const loadedDraft = loadCaptureDraft();
@@ -298,6 +322,7 @@ assert(loadedDraft !== null, 'Test 19: draft should be loaded');
 assert(loadedDraft.text === 'Черновик записи', 'Test 19: draft text should match');
 assert(loadedDraft.userHint === 'task', 'Test 19: draft userHint should match');
 assert(loadedDraft.inputType === 'voice', 'Test 19: draft inputType should match');
+assert(loadedDraft.entryPoint === 'shortcut', 'Test 19: draft entryPoint should match');
 assert(typeof loadedDraft.updatedAt === 'number', 'Test 19: draft should have updatedAt');
 console.log('✓ Test 19: draft serializes and deserializes');
 
@@ -325,6 +350,19 @@ assert(normalizeCaptureDraft({ text: '  ' }) === null, 'Test 22d: whitespace tex
 const normalized = normalizeCaptureDraft({ text: 'Нормализация', userHint: 'invalid', inputType: 'voice' });
 assert(normalized.userHint === null, 'Test 22e: invalid userHint should be null');
 assert(normalized.inputType === 'voice', 'Test 22f: valid inputType should pass');
+assert(normalized.entryPoint === 'app', 'Test 22g: old draft should default entryPoint to app');
 console.log('✓ Test 22: normalizeCaptureDraft handles invalid input');
+
+// Test 23: exact draft text and backward-compatible entryPoint
+resetState();
+const exactDraftText = '  строка один\nстрока два\n  ';
+assert(saveCaptureDraft({ text: exactDraftText, inputType: 'text', entryPoint: 'share' }), 'Test 23: exact draft should save');
+const exactDraft = loadCaptureDraft();
+assert(exactDraft.text === exactDraftText, 'Test 23: outer whitespace and newlines should survive save/load');
+assert(exactDraft.entryPoint === 'share', 'Test 23: entryPoint should survive save/load');
+memory.set('atlas_capture_draft_v1', JSON.stringify({ text: 'Старый черновик', inputType: 'text' }));
+const oldDraft = loadCaptureDraft();
+assert(oldDraft.entryPoint === 'app', 'Test 23: old draft without entryPoint should default to app');
+console.log('✓ Test 23: exact draft text and backward compatibility');
 
 console.log('\n✅ All capture persistence tests passed.');

--- a/tests/capture-pwa.mjs
+++ b/tests/capture-pwa.mjs
@@ -1,4 +1,10 @@
-import { buildShareDraft, applyShareDraft, mergeShareWithExisting } from '../js/capture/share-target.js';
+import {
+  buildShareDraft,
+  applyShareDraft,
+  mergeShareDrafts,
+  mergeShareWithExisting,
+  resolveShortcutEntryPoint,
+} from '../js/capture/share-target.js';
 import { readFileSync, existsSync, statSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -78,6 +84,7 @@ const draft1 = buildShareDraft('Title', 'Text', 'https://example.com');
 assert(draft1.text.includes('Title'), 'Test 7: parser should accept title');
 assert(draft1.text.includes('Text'), 'Test 7: parser should accept text');
 assert(draft1.text.includes('https://example.com'), 'Test 7: parser should accept url');
+assert(draft1.entryPoint === 'share', 'Test 7: shared draft should have share entryPoint');
 console.log('✓ Test 7: parser accepts action=share');
 
 // Test 8: parser accepts title/text/url without action
@@ -100,6 +107,28 @@ const cancelResult = applyShareDraft({ text: '' }, null);
 assert(cancelResult.action === 'cancel', 'Test 11: empty draft should return cancel');
 console.log('✓ Test 11: cancel result exists');
 
+// Test 11b: Share append/replace/reject provenance and shortcut rules
+const existingVoiceDraft = {
+  text: 'Existing',
+  userHint: 'thought',
+  inputType: 'voice',
+  entryPoint: 'app',
+};
+const sharedDraft = buildShareDraft('', 'Shared', '');
+const mergedDraft = mergeShareDrafts(existingVoiceDraft, sharedDraft);
+assert(mergedDraft.text === 'Existing\n\nShared', 'Test 11b: append should merge text');
+assert(mergedDraft.userHint === 'thought', 'Test 11b: append should preserve existing userHint');
+assert(mergedDraft.inputType === 'voice', 'Test 11b: append should preserve existing voice inputType');
+assert(mergedDraft.entryPoint === 'share', 'Test 11b: append should use share entryPoint');
+const replaceResult = applyShareDraft(sharedDraft, null);
+assert(replaceResult.draft.entryPoint === 'share', 'Test 11b: replace should use share entryPoint');
+const choiceResult = applyShareDraft(sharedDraft, existingVoiceDraft);
+assert(choiceResult.existing === existingVoiceDraft, 'Test 11b: reject path should preserve existing draft object');
+assert(resolveShortcutEntryPoint(null) === 'shortcut', 'Test 11b: shortcut without draft should use shortcut');
+assert(resolveShortcutEntryPoint(existingVoiceDraft) === 'app', 'Test 11b: shortcut should not replace existing provenance');
+assert(resolveShortcutEntryPoint({ ...existingVoiceDraft, entryPoint: 'share' }) === 'share', 'Test 11b: shortcut should preserve share draft provenance');
+console.log('✓ Test 11b: Share and shortcut provenance rules');
+
 // Test 12: PRECACHE_ASSETS exist on disk
 const swContent = readFileSync(join(projectRoot, 'capture', 'sw.js'), 'utf-8');
 const precacheMatch = swContent.match(/const PRECACHE_ASSETS = \[([\s\S]*?)\]/);
@@ -115,6 +144,11 @@ console.log('✓ Test 12: PRECACHE_ASSETS exist on disk');
 // Test 13: service worker does not have unconditional skipWaiting in install
 const installMatch = swContent.match(/addEventListener\('install'[\s\S]*?\}\)/);
 assert(!installMatch[0].includes('self.skipWaiting()'), 'Test 13: install should not have unconditional skipWaiting');
+const pwaModuleContent = readFileSync(join(projectRoot, 'js', 'capture', 'pwa.js'), 'utf-8');
+assert(
+  pwaModuleContent.includes('flushDraftCallback() === false'),
+  'Test 13: failed draft flush should postpone a user-confirmed update',
+);
 console.log('✓ Test 13: no unconditional skipWaiting in install');
 
 // Test 14: service worker routing is scope-relative
@@ -136,7 +170,7 @@ function collectStaticImportGraph(filePath, visited = new Set()) {
   visited.add(filePath);
 
   const source = readFileSync(filePath, 'utf-8');
-  const importPattern = /(?:import|export)\\s+(?:[^'"]*?\\s+from\\s+)?['"]([^'"]+)['"]/g;
+  const importPattern = /(?:import|export)\s+(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/g;
 
   for (const match of source.matchAll(importPattern)) {
     if (!match[1].startsWith('.')) continue;
@@ -165,9 +199,23 @@ assert(
 );
 console.log('✓ Test 16: complete Mobile Capture import graph is isolated and precached');
 
-// Test 17: version is 0.9.0-alpha.2
+// Test 17: version and cache are 0.9.0-alpha.3
 const { APP_VERSION } = await import('../js/version.js');
-assert(APP_VERSION === '0.9.0-alpha.2', 'Test 17: version should be 0.9.0-alpha.2');
-console.log('✓ Test 17: version is 0.9.0-alpha.2');
+assert(APP_VERSION === '0.9.0-alpha.3', 'Test 17: version should be 0.9.0-alpha.3');
+assert(swContent.includes("const CACHE_NAME = 'atlas-capture-0.9.0-alpha.3'"), 'Test 17: SW cache should be alpha.3');
+console.log('✓ Test 17: version and cache are 0.9.0-alpha.3');
+
+// Test 18: lifecycle, permission and accessibility wiring exists in the Capture shell
+const captureAppContent = readFileSync(join(projectRoot, 'js', 'capture', 'app.js'), 'utf-8');
+assert(captureAppContent.includes("window.addEventListener('pagehide', flushCaptureDraft)"), 'Test 18: pagehide should flush draft');
+assert(captureAppContent.includes("document.addEventListener('visibilitychange'"), 'Test 18: visibilitychange should be handled');
+assert(captureAppContent.includes('flushDraft: flushCaptureDraft'), 'Test 18: SW update should use common draft flush');
+assert(captureAppContent.includes("atlas_capture_mic_intro_v1"), 'Test 18: mic intro key should be explicit');
+assert(captureAppContent.includes('queryMicrophonePermission(navigator)'), 'Test 18: microphone permission should be queried from platform');
+assert(indexHtml.includes('id="micIntroDialog"'), 'Test 18: mic intro should use dialog');
+assert(indexHtml.includes('id="micDeniedDialog"'), 'Test 18: denied UX should use dialog');
+assert(indexHtml.includes('id="voiceStatus" aria-live="polite"'), 'Test 18: voice status should be announced accessibly');
+assert(indexHtml.includes('id="infoMicrophone"'), 'Test 18: info panel should show microphone status');
+console.log('✓ Test 18: lifecycle, permission and accessibility wiring');
 
 console.log('\n✅ All PWA tests passed.');

--- a/tests/capture-voice.mjs
+++ b/tests/capture-voice.mjs
@@ -1,0 +1,93 @@
+import {
+  VOICE_STATES,
+  appendFinalTranscript,
+  createVoiceController,
+  mapSpeechRecognitionError,
+  queryMicrophonePermission,
+} from '../js/capture/voice.js';
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const unsupported = createVoiceController({ scope: {} });
+assert(!unsupported.isSupported(), 'Unsupported browser should be detected');
+assert(unsupported.getState() === VOICE_STATES.UNSUPPORTED, 'Unsupported state should be explicit');
+console.log('✓ SpeechRecognition unsupported');
+
+for (const state of ['granted', 'prompt', 'denied']) {
+  const actual = await queryMicrophonePermission({
+    permissions: { query: async () => ({ state }) },
+  });
+  assert(actual === state, `Permission ${state} should be preserved`);
+}
+assert(await queryMicrophonePermission({}) === 'unknown', 'Missing Permissions API should be unknown');
+assert(
+  await queryMicrophonePermission({ permissions: { query: async () => { throw new Error('unsupported'); } } }) === 'unknown',
+  'Rejected permission query should be unknown',
+);
+assert(
+  await queryMicrophonePermission({ permissions: { query: async () => ({ state: 'unexpected' }) } }) === 'unknown',
+  'Unexpected permission state should be unknown',
+);
+console.log('✓ Permission granted/prompt/denied/unknown mapping');
+
+const errorCases = new Map([
+  ['not-allowed', VOICE_STATES.DENIED],
+  ['service-not-allowed', VOICE_STATES.DENIED],
+  ['no-speech', VOICE_STATES.NO_SPEECH],
+  ['audio-capture', VOICE_STATES.AUDIO_ERROR],
+  ['network', VOICE_STATES.NETWORK_ERROR],
+  ['language-not-supported', VOICE_STATES.LANGUAGE_ERROR],
+  ['language-unavailable', VOICE_STATES.LANGUAGE_ERROR],
+  ['aborted', VOICE_STATES.ABORTED],
+  ['anything-else', VOICE_STATES.GENERIC_ERROR],
+]);
+for (const [browserError, expectedState] of errorCases) {
+  assert(mapSpeechRecognitionError(browserError) === expectedState, `${browserError} should map to ${expectedState}`);
+}
+console.log('✓ Speech error mapping');
+
+assert(appendFinalTranscript('', '  Новая мысль  ') === 'Новая мысль', 'Append to empty text');
+assert(appendFinalTranscript('Купить фильтр', 'проверить насос') === 'Купить фильтр проверить насос', 'Append to ordinary text');
+assert(appendFinalTranscript('Купить фильтр ', 'проверить насос') === 'Купить фильтр проверить насос', 'Append after trailing space');
+assert(appendFinalTranscript('Купить фильтр\n', 'проверить насос') === 'Купить фильтр\nпроверить насос', 'Append after newline');
+assert(appendFinalTranscript('  исходный текст', 'результат') === '  исходный текст результат', 'Existing outer whitespace should remain');
+console.log('✓ Final transcript append preserves textarea formatting');
+
+let mockInstance = null;
+class MockRecognition {
+  constructor() {
+    mockInstance = this;
+  }
+  start() { this.onstart?.(); }
+  stop() { this.onend?.(); }
+  abort() { this.onerror?.({ error: 'aborted' }); this.onend?.(); }
+}
+
+const states = [];
+const finals = [];
+const controller = createVoiceController({
+  scope: { SpeechRecognition: MockRecognition },
+  onState: state => states.push(state),
+  onFinal: transcript => finals.push(transcript),
+});
+assert(controller.start(), 'Supported controller should start');
+assert(controller.getState() === VOICE_STATES.LISTENING, 'onstart should enter listening');
+
+const finalResult = [{ transcript: 'Проверить насос' }];
+finalResult.isFinal = true;
+const finalEvent = { resultIndex: 0, results: [finalResult] };
+mockInstance.onresult(finalEvent);
+mockInstance.onresult(finalEvent);
+
+assert(finals.length === 1, 'Duplicate final result index should be processed once per session');
+assert(finals[0] === 'Проверить насос', 'Final callback should receive transcript');
+assert(controller.getState() === VOICE_STATES.RESULT, 'Final transcript should enter result state');
+mockInstance.onend();
+assert(controller.getState() === VOICE_STATES.RESULT, 'onend should not erase result state');
+assert(states.includes(VOICE_STATES.REQUESTING), 'Controller should expose requesting state');
+assert(states.includes(VOICE_STATES.LISTENING), 'Controller should expose listening state');
+console.log('✓ Controller states and duplicate-final protection');
+
+console.log('\n✅ All capture voice tests passed.');


### PR DESCRIPTION
## Goal
Daily-use reliability for Atlas Capture before physical Android smoke.

## Product changes
- modular browser voice controller with explicit states and human-readable errors
- permission-aware microphone UX with one-time Atlas introduction and denied guidance
- lifecycle-safe drafts with one shared immediate flush path
- `entryPoint` provenance for app, Share Target, and manifest shortcut launches
- safer diagnostics, honest offline wording, and accessible voice/dialog states
- version and service-worker cache updated to `0.9.0-alpha.3`

## Data compatibility
- existing Inbox records remain valid and default missing `entryPoint` to `app`
- old drafts remain valid and default missing `entryPoint` to `app`
- exact draft whitespace and multiline text are preserved
- no storage migration or operation protocol redesign

## Verification
- `node --no-warnings tests/capture-voice.mjs` — PASS
- `node --no-warnings tests/capture-persistence.mjs` — PASS
- `node --no-warnings tests/capture-pwa.mjs` — PASS
- `powershell -ExecutionPolicy Bypass -File tools/verify-baseline.ps1` — PASS
- HTTP shell/module availability — PASS
- local interactive browser smoke — NOT TESTED (no connected browser in the agent environment)
- GitHub Actions `Revival baseline` — PASS ([run #10](https://github.com/DREDGV/atlas-of-life/actions/runs/31905926787))

## Deferred to A2
- physical Android microphone behavior
- actual Android permission behavior
- PWA lifecycle on a physical device
- Android Share smoke
- stress smoke

## Not included
- Native Android / Capacitor / Kotlin
- Sync, server, accounts, or pairing
- Mobile Today, Smart Inbox, or AI
- Map/Inspector redesign
- deployment work
